### PR TITLE
Support server passwords

### DIFF
--- a/syslog2irc/argparser.py
+++ b/syslog2irc/argparser.py
@@ -44,8 +44,10 @@ def create_arg_parser():
     parser.add_argument('--irc-server',
         dest='irc_server',
         type=parse_irc_server_arg,
-        help='IRC server (host and, optionally, port) to connect to'
-            + ' [e.g. "irc.example.com" or "irc.example.com:6669";'
+        help='IRC server (host and, optionally, port and password)'
+            + ' to connect to'
+            + ' [e.g. "irc.example.com", "irc.example.com:6669"'
+            + ' or "irc.example.com:6669:password;"'
             + ' default port: {:d}]'.format(DEFAULT_IRC_PORT),
         metavar='SERVER')
 
@@ -59,7 +61,7 @@ def create_arg_parser():
 
 def parse_irc_server_arg(value):
     """Parse a hostname with optional port."""
-    fragments = value.split(':', 1)
+    fragments = value.split(':', 2)
     if len(fragments) > 1:
         fragments[1] = int(fragments[1])
     return ServerSpec(*fragments)

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -32,14 +32,16 @@ class ArgumentParserTestCase(TestCase):
         self.assertEqual(actual.irc_realname, expected)
 
     @params(
-        (['--irc-server', 'localhost'     ], 'localhost', 6667),
-        (['--irc-server', '127.0.0.1'     ], '127.0.0.1', 6667),
-        (['--irc-server', '127.0.0.1:6669'], '127.0.0.1', 6669),
+        (['--irc-server', 'localhost'                  ], 'localhost', 6667, None          ),
+        (['--irc-server', '127.0.0.1'                  ], '127.0.0.1', 6667, None          ),
+        (['--irc-server', '127.0.0.1:6669'             ], '127.0.0.1', 6669, None          ),
+        (['--irc-server', '127.0.0.1:6669:testpassword'], '127.0.0.1', 6669, 'testpassword'),
     )
-    def test_parse_irc_server(self, arg_value, expected_host, expected_port):
+    def test_parse_irc_server(self, arg_value, expected_host, expected_port, expected_password):
         actual = parse_args(arg_value)
         self.assertEqual(actual.irc_server.host, expected_host)
         self.assertEqual(actual.irc_server.port, expected_port)
+        self.assertEqual(actual.irc_server.password, expected_password)
 
     @params(
         ([                  ], False),


### PR DESCRIPTION
This PR adds support for server passwords. The underlying IRC server_spec data structure already supports them, we just add them after the port.
